### PR TITLE
Potential fix for code scanning alert no. 9: Clear-text logging of sensitive information

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -485,7 +485,7 @@ async function testConfig() {
 
     const creds = getOAuthCredentials(conductor, 'google');
     if (!creds.redirectUri.includes('localhost')) {
-      throw new Error(`Expected localhost redirect, got ${creds.redirectUri}`);
+      throw new Error('Expected localhost redirect URI');
     }
 
     delete process.env.CONDUCTOR_GOOGLE_CLIENT_ID;


### PR DESCRIPTION
Potential fix for [https://github.com/thealxlabs/conductor/security/code-scanning/9](https://github.com/thealxlabs/conductor/security/code-scanning/9)

In general, the fix is to ensure that values derived from OAuth configuration (like the redirect URI) are not logged in clear text when an error occurs. We want to keep the helpful error context for developers while avoiding printing the raw, potentially sensitive, value.

The simplest, minimal-change fix is to adjust the specific test that constructs an error string including `creds.redirectUri`. Instead of embedding the actual redirect URI into the error message, we can use a generic message that describes the problem without revealing the exact value, or we can include a redacted / placeholder value. This way, if the test fails, the `fail` function will still log an error, but the logged text will no longer contain sensitive data. The rest of the logging infrastructure (`fail`, `test`, etc.) remains unchanged, and test behavior (pass/fail conditions) remains logically identical.

Concretely, in `test-all.mjs` around lines 480–489:

- Keep the assertion logic that checks `creds.redirectUri.includes('localhost')`.
- Change the `throw new Error(...)` message so that it does not interpolate `creds.redirectUri`. For example: `throw new Error('Expected localhost redirect URI');`.

No new imports or helper methods are required; this is a localized string change within the existing test block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified error messaging in configuration validation for improved consistency in URI validation feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->