### PR TITLE
Potential fix for code scanning alert no. 8: Clear-text logging of sensitive information

### DIFF
--- a/test-all.mjs
+++ b/test-all.mjs
@@ -490,7 +490,8 @@ async function testConfig() {
 
     delete process.env.CONDUCTOR_GOOGLE_CLIENT_ID;
     delete process.env.CONDUCTOR_GOOGLE_CLIENT_SECRET;
-    return creds.redirectUri;
+    // Do not return the redirect URI itself to avoid logging potentially sensitive data
+    return 'ok';
   });
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/thealxlabs/conductor/security/code-scanning/8](https://github.com/thealxlabs/conductor/security/code-scanning/8)

In general, to fix clear-text logging of sensitive information, you should avoid passing potentially sensitive values into logging functions or, if necessary, sanitize/mask them before logging. For test frameworks that log "detail" or "result" values, ensure that test callbacks return only non-sensitive summaries, not raw secrets or configuration values.

For this specific case, the tainted data reaches the sink because the test case `OAuth redirect URI defaults to localhost` returns `creds.redirectUri`, and `test()` passes that as `detail` into `pass()`, which logs it when `--verbose` is used. We can fix this without affecting test semantics by changing that test to return a non-sensitive string like `'ok'` instead of `creds.redirectUri`. The assertion `if (!creds.redirectUri.includes('localhost')) throw ...` already checks correctness, so the return value is only for logging. This breaks the taint flow while leaving behavior (pass/fail conditions) unchanged.

Concretely:
- In `test-all.mjs`, inside `async function testConfig()`, modify the `OAuth redirect URI defaults to localhost` test so that:
  - It no longer returns `creds.redirectUri`.
  - It returns a generic string (e.g., `'ok'`) after cleaning up environment variables.
No changes are needed to `pass()` or `getOAuthCredentials`; we only adjust the test's return value so that sensitive data is not logged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
